### PR TITLE
chore: upgrade TypeScript to 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "regenerator-runtime": "^0.14.1",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/tests/listy.behavior.test.tsx
+++ b/tests/listy.behavior.test.tsx
@@ -23,7 +23,7 @@ jest.mock('@rc-component/virtual-list', () => {
     getSize: () => ({ top: 0, bottom: 0 }),
   };
   let scrollHandler = (config: any) => {};
-  let lastProps = null;
+  let lastProps: any = null;
 
   const MockVirtualList = React.forwardRef((props: any, ref: any) => {
     lastProps = props;
@@ -286,7 +286,7 @@ describe('Listy behaviors', () => {
         ref={ref}
         data={[{ id: 1 }]}
         group={undefined}
-        itemRender={(item) => <div>{item.id}</div>}
+        itemRender={(item: { id: number }) => <div>{item.id}</div>}
         prefixCls="rc-listy"
         rowKey="id"
       />,
@@ -308,7 +308,7 @@ describe('Listy behaviors', () => {
           key: (item: { id: number; group: string }) => item.group,
           title,
         }}
-        itemRender={(item) => <div>{item.id}</div>}
+        itemRender={(item: { id: number }) => <div>{item.id}</div>}
         prefixCls="rc-listy"
         rowKey="id"
       />,
@@ -325,9 +325,9 @@ describe('Listy behaviors', () => {
       <RawList
         data={[{ id: 1 }]}
         group={undefined}
-        itemRender={(item) => <div>{item.id}</div>}
+        itemRender={(item: { id: number }) => <div>{item.id}</div>}
         prefixCls="rc-listy"
-        rowKey={(item) => `item-${item.id}`}
+        rowKey={(item: { id: number }) => `item-${item.id}`}
       />,
     );
 
@@ -341,7 +341,7 @@ describe('Listy behaviors', () => {
       <RawList
         data={[{ id: 1 }]}
         group={undefined}
-        itemRender={(item) => (
+        itemRender={(item: { id: number }) => (
           <>
             <span>{item.id}</span>
           </>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,16 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "moduleResolution": "node",
-    "baseUrl": "./",
+    "moduleResolution": "bundler",
     "jsx": "react",
     "declaration": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "paths": {
-      "@/*": ["src/*"],
-      "@@/*": [".dumi/tmp/*"],
-      "@rc-component/listy": ["src/index.ts"]
+      "@/*": ["./src/*"],
+      "@@/*": ["./.dumi/tmp/*"],
+      "@rc-component/listy": ["./src/index.ts"]
     },
     "types": ["@testing-library/jest-dom", "node"]
   }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,1 @@
+declare module '*.less';


### PR DESCRIPTION
## Summary
- Bump `typescript` from `^5.9.3` to `^6.0.3` — the latest **stable** release, still the JS-based compiler and compatible with the existing toolchain.
- Modernize `tsconfig.json` for 6.x deprecations (which become hard errors in 7.0), fixing them properly instead of suppressing with `ignoreDeprecations`:
  - `moduleResolution: node` → `bundler`
  - drop deprecated `baseUrl`
  - make `paths` mappings relative

### Why not TypeScript 7?
TS 7 is the native (Go) compiler rewrite. Its npm package ships only the `tsc` binary plus an experimental `typescript/unstable/*` API — it **does not expose `require('typescript')`**, the JS compiler API that `father` (dts generation) and `@typescript-eslint` depend on. `npm run compile` fails on native TS7 (`ERR_PACKAGE_PATH_NOT_EXPORTED`). 6.0.3 is the newest usable TS today; this tsconfig is already 7.0-ready for when the ecosystem catches up.

## Test plan
- [x] `npm run compile` — father bundless (es/lib) + declaration generation + eslint hook all pass
- [x] `npm test` — 28/28 pass
- [x] `tsc --noEmit` on `src/` — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 升级了 TypeScript 版本，并更新了编译配置以适配新的模块解析方式。
  * 路径映射写法已调整为更明确的相对路径格式，提升了配置一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->