### PR TITLE
fix: stop sticky group header jitter while scrolling

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -2,6 +2,7 @@
 
 .@{listy-prefix-cls} {
   position: relative;
+  overflow: hidden;
 
   &-group-header {
     background-color: #fff;

--- a/assets/index.less
+++ b/assets/index.less
@@ -2,7 +2,6 @@
 
 .@{listy-prefix-cls} {
   position: relative;
-  overflow: hidden;
 
   &-group-header {
     background-color: #fff;
@@ -21,6 +20,17 @@
       left: 0;
       right: 0;
       transform: translateY(0);
+      pointer-events: auto;
+    }
+
+    &-holder {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      overflow: hidden;
+      pointer-events: none;
     }
   }
 

--- a/src/VirtualList/index.tsx
+++ b/src/VirtualList/index.tsx
@@ -138,6 +138,7 @@ function VirtualList<T, K extends React.Key = React.Key>(
     headerRows,
     groupKeyToItems,
     prefixCls,
+    listRef,
   });
 
   // ============================ Render Row ============================

--- a/src/VirtualList/useStickyGroupHeader.tsx
+++ b/src/VirtualList/useStickyGroupHeader.tsx
@@ -92,14 +92,16 @@ export default function useStickyGroupHeader<
       // Render a cloned header pinned over the virtual list.
       return (
         <Portal open getContainer={() => container}>
-          <GroupHeader
-            fixed
-            group={group}
-            groupKey={currHeader.groupKey}
-            groupItems={groupItems}
-            prefixCls={prefixCls}
-            style={{ top }}
-          />
+          <div className={`${prefixCls}-group-header-holder`}>
+            <GroupHeader
+              fixed
+              group={group}
+              groupKey={currHeader.groupKey}
+              groupItems={groupItems}
+              prefixCls={prefixCls}
+              style={{ top }}
+            />
+          </div>
         </Portal>
       );
     },

--- a/src/VirtualList/useStickyGroupHeader.tsx
+++ b/src/VirtualList/useStickyGroupHeader.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import type { ListProps as VirtualListProps } from '@rc-component/virtual-list';
+import Portal from '@rc-component/portal';
+import type {
+  ListProps as VirtualListProps,
+  ListRef as RcVirtualListRef,
+} from '@rc-component/virtual-list';
 import type { Group } from '../hooks/useGroupSegments';
 import GroupHeader from '../GroupHeader';
 
@@ -41,6 +45,7 @@ export interface StickyHeaderParams<T, K extends React.Key = React.Key> {
   headerRows: HeaderRow<K>[];
   groupKeyToItems: Map<K, T[]>;
   prefixCls: string;
+  listRef: React.RefObject<RcVirtualListRef | null>;
 }
 
 export default function useStickyGroupHeader<
@@ -54,14 +59,20 @@ export default function useStickyGroupHeader<
     headerRows,
     groupKeyToItems,
     prefixCls,
+    listRef,
   } = params;
 
   // ============================ Extra Render ==========================
   const extraRender = React.useCallback(
     (info: ExtraRenderInfo) => {
-      const { getSize, offsetY, scrollTop, start, virtual } = info;
+      const { getSize, scrollTop, start, virtual } = info;
 
       if (!enabled || !group || !headerRows.length || !virtual) {
+        return null;
+      }
+
+      const container = listRef.current?.nativeElement;
+      if (!container) {
         return null;
       }
 
@@ -73,29 +84,26 @@ export default function useStickyGroupHeader<
       const currentSize = getSize(currHeader.groupKey);
       const headerHeight = currentSize.bottom - currentSize.top;
 
-      // Convert the virtual list scroll position into the overlay top offset.
-      const fixedTop = scrollTop - offsetY;
-
-      // Let the next group header push the current fixed header away.
       const nextHeader = headerRows[activeHeaderIdx + 1];
-      const nextTop = nextHeader
-        ? getSize(nextHeader.groupKey).top - headerHeight - offsetY
-        : fixedTop;
-      const top = Math.min(fixedTop, nextTop);
+      const top = nextHeader
+        ? Math.min(0, getSize(nextHeader.groupKey).top - headerHeight - scrollTop)
+        : 0;
 
-      // Render a cloned header above the virtual list items.
+      // Render a cloned header pinned over the virtual list.
       return (
-        <GroupHeader
-          fixed
-          group={group}
-          groupKey={currHeader.groupKey}
-          groupItems={groupItems}
-          prefixCls={prefixCls}
-          style={{ top }}
-        />
+        <Portal open getContainer={() => container}>
+          <GroupHeader
+            fixed
+            group={group}
+            groupKey={currHeader.groupKey}
+            groupItems={groupItems}
+            prefixCls={prefixCls}
+            style={{ top }}
+          />
+        </Portal>
       );
     },
-    [enabled, group, headerRows, groupKeyToItems, prefixCls],
+    [enabled, group, headerRows, groupKeyToItems, prefixCls, listRef],
   );
 
   // ============================== Return ==============================

--- a/tests/hooks.test.tsx
+++ b/tests/hooks.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { render, renderHook } from '@testing-library/react';
-import type { ListProps as VirtualListProps } from '@rc-component/virtual-list';
+import type {
+  ListProps as VirtualListProps,
+  ListRef as RcVirtualListRef,
+} from '@rc-component/virtual-list';
 
 import useGroupSegments from '../src/hooks/useGroupSegments';
 import useFlattenRows from '../src/VirtualList/useFlattenRows';
@@ -42,6 +45,13 @@ const StickyHeaderTester = ({
   const extraRender = useStickyGroupHeader<GroupedItem>(params);
   return <>{extraRender(info)}</>;
 };
+
+const createListRef = (
+  nativeElement: HTMLElement,
+): React.RefObject<RcVirtualListRef | null> =>
+  ({ current: { nativeElement } } as unknown as React.RefObject<
+    RcVirtualListRef | null
+  >);
 
 describe('useGroupSegments', () => {
   it('groups items by key across the full data set', () => {
@@ -191,6 +201,8 @@ describe('useStickyGroupHeader', () => {
         </span>
       ));
     const info = createRenderInfo({ scrollTop: 5, start: 5 });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
     const params: StickyHeaderParams<GroupedItem> = {
       enabled: true,
       group: {
@@ -200,25 +212,28 @@ describe('useStickyGroupHeader', () => {
       headerRows,
       groupKeyToItems: baseItemsMap,
       prefixCls: PREFIX_CLS,
+      listRef: createListRef(container),
     };
 
-    const { container: renderContainer } = render(
-      <StickyHeaderTester params={params} info={info} />,
-    );
+    render(<StickyHeaderTester params={params} info={info} />);
 
-    const stickyHeader = renderContainer.querySelector(
+    const stickyHeader = container.querySelector(
       `.${PREFIX_CLS}-group-header-fixed`,
     );
     expect(stickyHeader).not.toBeNull();
     expect(stickyHeader).toHaveClass(`${PREFIX_CLS}-group-header`);
     expect(stickyHeader).toHaveClass(`${PREFIX_CLS}-group-header-fixed`);
     expect(stickyHeader).toHaveTextContent('Group 2-3');
-    expect(stickyHeader).toHaveStyle({ top: '5px' });
+    // Last group, nothing to push it: pinned at the container top.
+    expect(stickyHeader).toHaveStyle({ top: '0px' });
     expect(title).toHaveBeenCalledWith('Group 2', baseItems.slice(3, 6));
+    document.body.removeChild(container);
   });
 
   it('skips sticky header rendering when virtual list is disabled', () => {
     const info = createRenderInfo({ virtual: false });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
     const params: StickyHeaderParams<GroupedItem> = {
       enabled: true,
       group: {
@@ -228,16 +243,16 @@ describe('useStickyGroupHeader', () => {
       headerRows,
       groupKeyToItems: baseItemsMap,
       prefixCls: PREFIX_CLS,
+      listRef: createListRef(container),
     };
 
-    const { container: renderContainer } = render(
-      <StickyHeaderTester params={params} info={info} />,
-    );
+    render(<StickyHeaderTester params={params} info={info} />);
 
-    const stickyHeader = renderContainer.querySelector(
+    const stickyHeader = container.querySelector(
       `.${PREFIX_CLS}-group-header-fixed`,
     );
     expect(stickyHeader).toBeNull();
+    document.body.removeChild(container);
   });
 
   it('uses the visible start row to resolve the active header', () => {
@@ -246,11 +261,12 @@ describe('useStickyGroupHeader', () => {
     ));
 
     const info = createRenderInfo({
-      offsetY: 80,
       scrollTop: 80,
       start: 4,
     });
 
+    const container = document.createElement('div');
+    document.body.appendChild(container);
     const params: StickyHeaderParams<GroupedItem> = {
       enabled: true,
       group: {
@@ -260,32 +276,36 @@ describe('useStickyGroupHeader', () => {
       headerRows,
       groupKeyToItems: baseItemsMap,
       prefixCls: PREFIX_CLS,
+      listRef: createListRef(container),
     };
 
-    const { container: renderContainer } = render(
-      <StickyHeaderTester params={params} info={info} />,
-    );
+    render(<StickyHeaderTester params={params} info={info} />);
 
-    const stickyHeader = renderContainer.querySelector(
+    const stickyHeader = container.querySelector(
       `.${PREFIX_CLS}-group-header-fixed`,
     );
     expect(stickyHeader).not.toBeNull();
     expect(stickyHeader).toHaveTextContent('Group 2');
     expect(stickyHeader).toHaveStyle({ top: '0px' });
     expect(title).toHaveBeenCalledWith('Group 2', baseItems.slice(3, 6));
+    document.body.removeChild(container);
   });
 
-  it('offsets the fixed header by the extra render scrollTop', () => {
+  it('keeps the fixed header pinned at 0 within a group regardless of scroll', () => {
     const title = jest.fn().mockImplementation((key: React.Key) => (
       <span data-testid="sticky-title">{String(key)}</span>
     ));
 
+    // Active group is Group 1, with Group 2's header far below the viewport.
     const info = createRenderInfo({
-      offsetY: 64,
       scrollTop: 80,
-      start: 4,
+      start: 1,
+      getSize: (key: React.Key) =>
+        key === 'Group 2' ? { top: 500, bottom: 524 } : { top: 0, bottom: 24 },
     });
 
+    const container = document.createElement('div');
+    document.body.appendChild(container);
     const params: StickyHeaderParams<GroupedItem> = {
       enabled: true,
       group: {
@@ -295,18 +315,18 @@ describe('useStickyGroupHeader', () => {
       headerRows,
       groupKeyToItems: baseItemsMap,
       prefixCls: PREFIX_CLS,
+      listRef: createListRef(container),
     };
 
-    const { container: renderContainer } = render(
-      <StickyHeaderTester params={params} info={info} />,
-    );
+    render(<StickyHeaderTester params={params} info={info} />);
 
-    const stickyHeader = renderContainer.querySelector(
+    const stickyHeader = container.querySelector(
       `.${PREFIX_CLS}-group-header-fixed`,
     );
     expect(stickyHeader).not.toBeNull();
-    expect(stickyHeader).toHaveTextContent('Group 2');
-    expect(stickyHeader).toHaveStyle({ top: '16px' });
+    expect(stickyHeader).toHaveTextContent('Group 1');
+    expect(stickyHeader).toHaveStyle({ top: '0px' });
+    document.body.removeChild(container);
   });
 
   it('pushes the fixed header away when the next group reaches the top', () => {
@@ -315,7 +335,6 @@ describe('useStickyGroupHeader', () => {
     ));
 
     const info = createRenderInfo({
-      offsetY: 64,
       scrollTop: 70,
       start: 3,
       getSize: (key: React.Key) => {
@@ -329,6 +348,8 @@ describe('useStickyGroupHeader', () => {
       },
     });
 
+    const container = document.createElement('div');
+    document.body.appendChild(container);
     const params: StickyHeaderParams<GroupedItem> = {
       enabled: true,
       group: {
@@ -338,17 +359,17 @@ describe('useStickyGroupHeader', () => {
       headerRows,
       groupKeyToItems: baseItemsMap,
       prefixCls: PREFIX_CLS,
+      listRef: createListRef(container),
     };
 
-    const { container: renderContainer } = render(
-      <StickyHeaderTester params={params} info={info} />,
-    );
+    render(<StickyHeaderTester params={params} info={info} />);
 
-    const stickyHeader = renderContainer.querySelector(
+    const stickyHeader = container.querySelector(
       `.${PREFIX_CLS}-group-header-fixed`,
     );
     expect(stickyHeader).not.toBeNull();
     expect(stickyHeader).toHaveTextContent('Group 1');
-    expect(stickyHeader).toHaveStyle({ top: '-4px' });
+    expect(stickyHeader).toHaveStyle({ top: '-10px' });
+    document.body.removeChild(container);
   });
 });

--- a/tests/hooks.test.tsx
+++ b/tests/hooks.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, renderHook } from '@testing-library/react';
+import { cleanup, render, renderHook } from '@testing-library/react';
 import type {
   ListProps as VirtualListProps,
   ListRef as RcVirtualListRef,
@@ -192,6 +192,11 @@ describe('useStickyGroupHeader', () => {
     ['Group 2', baseItems.slice(3, 6)],
   ]);
 
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = '';
+  });
+
   it('renders sticky header for the active header row', () => {
     const title = jest
       .fn()
@@ -226,9 +231,7 @@ describe('useStickyGroupHeader', () => {
     expect(stickyHeader).toHaveTextContent('Group 2-3');
     // Last group, nothing to push it: pinned at the container top.
     expect(stickyHeader).toHaveStyle({ top: '0px' });
-    expect(title).toHaveBeenCalledWith('Group 2', baseItems.slice(3, 6));
-    document.body.removeChild(container);
-  });
+    expect(title).toHaveBeenCalledWith('Group 2', baseItems.slice(3, 6));  });
 
   it('skips sticky header rendering when virtual list is disabled', () => {
     const info = createRenderInfo({ virtual: false });
@@ -251,9 +254,7 @@ describe('useStickyGroupHeader', () => {
     const stickyHeader = container.querySelector(
       `.${PREFIX_CLS}-group-header-fixed`,
     );
-    expect(stickyHeader).toBeNull();
-    document.body.removeChild(container);
-  });
+    expect(stickyHeader).toBeNull();  });
 
   it('uses the visible start row to resolve the active header', () => {
     const title = jest.fn().mockImplementation((key: React.Key) => (
@@ -287,9 +288,7 @@ describe('useStickyGroupHeader', () => {
     expect(stickyHeader).not.toBeNull();
     expect(stickyHeader).toHaveTextContent('Group 2');
     expect(stickyHeader).toHaveStyle({ top: '0px' });
-    expect(title).toHaveBeenCalledWith('Group 2', baseItems.slice(3, 6));
-    document.body.removeChild(container);
-  });
+    expect(title).toHaveBeenCalledWith('Group 2', baseItems.slice(3, 6));  });
 
   it('keeps the fixed header pinned at 0 within a group regardless of scroll', () => {
     const title = jest.fn().mockImplementation((key: React.Key) => (
@@ -325,9 +324,7 @@ describe('useStickyGroupHeader', () => {
     );
     expect(stickyHeader).not.toBeNull();
     expect(stickyHeader).toHaveTextContent('Group 1');
-    expect(stickyHeader).toHaveStyle({ top: '0px' });
-    document.body.removeChild(container);
-  });
+    expect(stickyHeader).toHaveStyle({ top: '0px' });  });
 
   it('pushes the fixed header away when the next group reaches the top', () => {
     const title = jest.fn().mockImplementation((key: React.Key) => (
@@ -369,7 +366,5 @@ describe('useStickyGroupHeader', () => {
     );
     expect(stickyHeader).not.toBeNull();
     expect(stickyHeader).toHaveTextContent('Group 1');
-    expect(stickyHeader).toHaveStyle({ top: '-10px' });
-    document.body.removeChild(container);
-  });
+    expect(stickyHeader).toHaveStyle({ top: '-10px' });  });
 });


### PR DESCRIPTION
## Summary

Fixes a subtle jitter of the sticky group header when scrolling up and down within a group (reproducible in the `group` demo).

## Root cause

The sticky header overlay is rendered through rc-virtual-list's `extraRender`, which places it **inside** the natively-scrolled holder (the `translateY(offsetY)` container). To keep it visually pinned, listy recomputed its `top` as `scrollTop - offsetY` on every React render.

But the two positioning channels are not in sync:

- The list content scrolls via the holder's **native `scrollTop`** — applied synchronously, takes effect the same frame.
- The overlay's compensating `top` is applied through a **React render/commit**, which can paint **one frame later**.

On frames where the native scroll has already advanced but the re-render carrying the new `top` hasn't committed yet, the header is left under-compensated by exactly one scroll step and then snaps back the next frame. The list items, driven directly by native scroll, move correctly — so only the header appears to shake.

Per-frame measurement before the fix (fresh downward scroll) caught transient frames where the header's on-screen position was a full scroll step off its intended `styleTop` (e.g. rendered at `-16px` while it should be `0`).

## Fix

Render the overlay into the **outer, non-scrolled** list container (`listRef.nativeElement`) via `Portal`, and make `top` viewport-relative:

```ts
const top = nextHeader
  ? Math.min(0, getSize(nextHeader.groupKey).top - headerHeight - scrollTop)
  : 0;
```

- Within a group the value is a static `0` — there is no per-frame scroll compensation, so nothing can lag → no jitter.
- The next group header still pushes the current one up (`top` goes negative) near a boundary, so the push animation is preserved.
- Because the overlay now lives in the non-clipping outer container, a pushed-up header could bleed above the list over surrounding content; `overflow: hidden` on the list root clips it back to the list viewport (the natural "slide out the top" behavior).

## Verification

Per-frame sampling in a foreground browser at full frame rate:

- Within-group aggressive up/down (160 frames): **0 jitter frames, 0 header/scroll desync**.
- After the fix the header's on-screen position equals its `styleTop` on **every** frame — the desync channel is eliminated by construction.
- Boundary push: monotonic slide-up, clipped at the list top, no overflow over surrounding controls.
- All unit tests pass (28). `useStickyGroupHeader` tests updated for the new viewport-relative contract.

## Before / After

**Before** (header jitters while scrolling within a group)

<img width="1280" height="720" alt="Clipboard-20260627-185526-935" src="https://github.com/user-attachments/assets/e83efdb8-d485-4018-9ec3-0c6bdb133050" />

**After** (header stays pinned; push animation clipped to the list)

<img width="1280" height="720" alt="Clipboard-20260627-174305-770" src="https://github.com/user-attachments/assets/ca698698-f020-463a-b1fb-de691427c6a0" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化虚拟列表分组表头在滚动与吸附场景下的定位计算，固定位置更准确。
  * 调整分组承载层的交互与溢出表现：承载层内容将按范围裁剪，同时继续正确屏蔽指针事件。
* **Tests**
  * 更新并完善分组表头定位相关用例断言，覆盖虚拟列表启用/禁用及滚动偏移情况。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->