### PR TITLE
fix: show the correct group header when scrolled flush to its top

### DIFF
--- a/src/VirtualList/index.tsx
+++ b/src/VirtualList/index.tsx
@@ -58,7 +58,7 @@ function VirtualList<T, K extends React.Key = React.Key>(
   });
 
   // ============================== Rows ================================
-  const { rows, headerRows, groupKeyToItems } = useFlattenRows<T, K>(
+  const { rows, groupKeys, groupKeyToItems } = useFlattenRows<T, K>(
     data,
     groupData,
     group,
@@ -135,7 +135,7 @@ function VirtualList<T, K extends React.Key = React.Key>(
   const extraRender = useStickyGroupHeader<T, K>({
     enabled: !!(sticky && group),
     group,
-    headerRows,
+    groupKeys,
     groupKeyToItems,
     prefixCls,
     listRef,

--- a/src/VirtualList/useFlattenRows.ts
+++ b/src/VirtualList/useFlattenRows.ts
@@ -8,7 +8,7 @@ export type Row<T, K extends React.Key = React.Key> =
 
 export interface FlattenRowsResult<T, K extends React.Key = React.Key> {
   rows: Row<T, K>[];
-  headerRows: { groupKey: K; rowIndex: number }[];
+  groupKeys: K[];
   groupKeyToItems: Map<K, T[]>;
 }
 
@@ -25,7 +25,7 @@ export default function useFlattenRows<T, K extends React.Key = React.Key>(
   return React.useMemo(() => {
     // ============================== Init ================================
     const flatRows: Row<T, K>[] = [];
-    const headerRows: { groupKey: K; rowIndex: number }[] = [];
+    const groupKeys: K[] = [];
     const groupKeyToItems = new Map<K, T[]>();
 
     // ============================ No Group ==============================
@@ -34,7 +34,7 @@ export default function useFlattenRows<T, K extends React.Key = React.Key>(
         flatRows.push({ type: 'item', item, index });
       });
 
-      return { rows: flatRows, headerRows, groupKeyToItems };
+      return { rows: flatRows, groupKeys, groupKeyToItems };
     }
 
     // ============================= Flatten ==============================
@@ -44,7 +44,7 @@ export default function useFlattenRows<T, K extends React.Key = React.Key>(
         groupItems.map(({ item }) => item),
       );
 
-      headerRows.push({ groupKey, rowIndex: flatRows.length });
+      groupKeys.push(groupKey);
       flatRows.push({ type: 'header', groupKey });
 
       groupItems.forEach(({ item, index }) => {
@@ -53,6 +53,6 @@ export default function useFlattenRows<T, K extends React.Key = React.Key>(
     });
 
     // ============================== Return ==============================
-    return { rows: flatRows, headerRows, groupKeyToItems };
+    return { rows: flatRows, groupKeys, groupKeyToItems };
   }, [data, group, groupData]);
 }

--- a/src/VirtualList/useStickyGroupHeader.tsx
+++ b/src/VirtualList/useStickyGroupHeader.tsx
@@ -12,22 +12,20 @@ type ExtraRenderInfo = Parameters<
   NonNullable<VirtualListProps<unknown>['extraRender']>
 >[0];
 
-type HeaderRow<K extends React.Key> = { groupKey: K; rowIndex: number };
-
 // ============================== Utils ===============================
-// `headerRows` is sorted by rowIndex. Find the last header not after `start`.
 function findActiveHeaderIndex<K extends React.Key>(
-  headerRows: HeaderRow<K>[],
-  start: number,
+  groupKeys: K[],
+  getHeaderTop: (groupKey: K) => number,
+  scrollTop: number,
 ) {
   let left = 0;
-  let right = headerRows.length - 1;
+  let right = groupKeys.length - 1;
   let activeIndex = 0;
 
   while (left <= right) {
     const mid = Math.floor((left + right) / 2);
 
-    if (headerRows[mid].rowIndex <= start) {
+    if (getHeaderTop(groupKeys[mid]) <= scrollTop) {
       activeIndex = mid;
       left = mid + 1;
     } else {
@@ -42,7 +40,7 @@ function findActiveHeaderIndex<K extends React.Key>(
 export interface StickyHeaderParams<T, K extends React.Key = React.Key> {
   enabled: boolean;
   group: Group<T, K> | undefined;
-  headerRows: HeaderRow<K>[];
+  groupKeys: K[];
   groupKeyToItems: Map<K, T[]>;
   prefixCls: string;
   listRef: React.RefObject<RcVirtualListRef | null>;
@@ -56,7 +54,7 @@ export default function useStickyGroupHeader<
   const {
     enabled,
     group,
-    headerRows,
+    groupKeys,
     groupKeyToItems,
     prefixCls,
     listRef,
@@ -65,9 +63,9 @@ export default function useStickyGroupHeader<
   // ============================ Extra Render ==========================
   const extraRender = React.useCallback(
     (info: ExtraRenderInfo) => {
-      const { getSize, scrollTop, start, virtual } = info;
+      const { getSize, scrollTop, virtual } = info;
 
-      if (!enabled || !group || !headerRows.length || !virtual) {
+      if (!enabled || !group || !groupKeys.length || !virtual) {
         return null;
       }
 
@@ -76,17 +74,21 @@ export default function useStickyGroupHeader<
         return null;
       }
 
-      // The sticky header is the latest group header before the visible range.
-      const activeHeaderIdx = findActiveHeaderIndex(headerRows, start);
-      const currHeader = headerRows[activeHeaderIdx];
+      // The sticky header is the group whose section the viewport top sits in.
+      const activeHeaderIdx = findActiveHeaderIndex(
+        groupKeys,
+        (groupKey) => getSize(groupKey).top,
+        scrollTop,
+      );
+      const currGroupKey = groupKeys[activeHeaderIdx];
 
-      const groupItems = groupKeyToItems.get(currHeader.groupKey) || [];
-      const currentSize = getSize(currHeader.groupKey);
+      const groupItems = groupKeyToItems.get(currGroupKey) || [];
+      const currentSize = getSize(currGroupKey);
       const headerHeight = currentSize.bottom - currentSize.top;
 
-      const nextHeader = headerRows[activeHeaderIdx + 1];
-      const top = nextHeader
-        ? Math.min(0, getSize(nextHeader.groupKey).top - headerHeight - scrollTop)
+      const nextGroupKey = groupKeys[activeHeaderIdx + 1];
+      const top = nextGroupKey
+        ? Math.min(0, getSize(nextGroupKey).top - headerHeight - scrollTop)
         : 0;
 
       // Render a cloned header pinned over the virtual list.
@@ -96,7 +98,7 @@ export default function useStickyGroupHeader<
             <GroupHeader
               fixed
               group={group}
-              groupKey={currHeader.groupKey}
+              groupKey={currGroupKey}
               groupItems={groupItems}
               prefixCls={prefixCls}
               style={{ top }}
@@ -105,7 +107,7 @@ export default function useStickyGroupHeader<
         </Portal>
       );
     },
-    [enabled, group, headerRows, groupKeyToItems, prefixCls, listRef],
+    [enabled, group, groupKeys, groupKeyToItems, prefixCls, listRef],
   );
 
   // ============================== Return ==============================

--- a/src/VirtualList/useStickyGroupHeader.tsx
+++ b/src/VirtualList/useStickyGroupHeader.tsx
@@ -13,6 +13,14 @@ type ExtraRenderInfo = Parameters<
 >[0];
 
 // ============================== Utils ===============================
+// `scrollTop` is the (possibly sub-pixel rounded) scroll offset while header
+// tops come from summed item heights, so the two can disagree by a fraction of
+// a pixel. On a Retina/HiDPI screen a trackpad scroll routinely rests ~0.5px
+// short of a header top; without slack the strict compare would resolve to the
+// previous group and pin a stale header off-screen. 1px absorbs the rounding
+// and is far smaller than any real gap between consecutive headers.
+const HEADER_TOP_TOLERANCE = 1;
+
 function findActiveHeaderIndex<K extends React.Key>(
   groupKeys: K[],
   getHeaderTop: (groupKey: K) => number,
@@ -25,7 +33,7 @@ function findActiveHeaderIndex<K extends React.Key>(
   while (left <= right) {
     const mid = Math.floor((left + right) / 2);
 
-    if (getHeaderTop(groupKeys[mid]) <= scrollTop) {
+    if (getHeaderTop(groupKeys[mid]) <= scrollTop + HEADER_TOP_TOLERANCE) {
       activeIndex = mid;
       left = mid + 1;
     } else {

--- a/src/VirtualList/useStickyGroupHeader.tsx
+++ b/src/VirtualList/useStickyGroupHeader.tsx
@@ -13,12 +13,6 @@ type ExtraRenderInfo = Parameters<
 >[0];
 
 // ============================== Utils ===============================
-// `scrollTop` is the (possibly sub-pixel rounded) scroll offset while header
-// tops come from summed item heights, so the two can disagree by a fraction of
-// a pixel. On a Retina/HiDPI screen a trackpad scroll routinely rests ~0.5px
-// short of a header top; without slack the strict compare would resolve to the
-// previous group and pin a stale header off-screen. 1px absorbs the rounding
-// and is far smaller than any real gap between consecutive headers.
 const HEADER_TOP_TOLERANCE = 1;
 
 function findActiveHeaderIndex<K extends React.Key>(

--- a/tests/hooks.test.tsx
+++ b/tests/hooks.test.tsx
@@ -140,10 +140,7 @@ describe('useFlattenRows', () => {
       { type: 'header', groupKey: 'B' },
       { type: 'item', item: items[1], index: 1 },
     ]);
-    expect(result.current.headerRows).toEqual([
-      { groupKey: 'A', rowIndex: 0 },
-      { groupKey: 'B', rowIndex: 3 },
-    ]);
+    expect(result.current.groupKeys).toEqual(['A', 'B']);
     expect(result.current.groupKeyToItems).toEqual(
       new Map([
         ['A', [items[0], items[2]]],
@@ -168,7 +165,7 @@ describe('useFlattenRows', () => {
         { type: 'item', item: items[0], index: 0 },
         { type: 'item', item: items[1], index: 1 },
       ],
-      headerRows: [],
+      groupKeys: [],
       groupKeyToItems: new Map(),
     });
   });
@@ -183,10 +180,7 @@ describe('useStickyGroupHeader', () => {
     { id: 4, group: 'Group 2' },
     { id: 5, group: 'Group 2' },
   ];
-  const headerRows = [
-    { groupKey: 'Group 1', rowIndex: 0 },
-    { groupKey: 'Group 2', rowIndex: 4 },
-  ];
+  const groupKeys = ['Group 1', 'Group 2'];
   const baseItemsMap = new Map<React.Key, GroupedItem[]>([
     ['Group 1', baseItems.slice(0, 3)],
     ['Group 2', baseItems.slice(3, 6)],
@@ -214,7 +208,7 @@ describe('useStickyGroupHeader', () => {
         key: (item) => item.group,
         title,
       },
-      headerRows,
+      groupKeys,
       groupKeyToItems: baseItemsMap,
       prefixCls: PREFIX_CLS,
       listRef: createListRef(container),
@@ -243,7 +237,7 @@ describe('useStickyGroupHeader', () => {
         key: (item) => item.group,
         title: () => <span>noop</span>,
       },
-      headerRows,
+      groupKeys,
       groupKeyToItems: baseItemsMap,
       prefixCls: PREFIX_CLS,
       listRef: createListRef(container),
@@ -255,40 +249,6 @@ describe('useStickyGroupHeader', () => {
       `.${PREFIX_CLS}-group-header-fixed`,
     );
     expect(stickyHeader).toBeNull();  });
-
-  it('uses the visible start row to resolve the active header', () => {
-    const title = jest.fn().mockImplementation((key: React.Key) => (
-      <span data-testid="sticky-title">{String(key)}</span>
-    ));
-
-    const info = createRenderInfo({
-      scrollTop: 80,
-      start: 4,
-    });
-
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const params: StickyHeaderParams<GroupedItem> = {
-      enabled: true,
-      group: {
-        key: (item) => item.group,
-        title,
-      },
-      headerRows,
-      groupKeyToItems: baseItemsMap,
-      prefixCls: PREFIX_CLS,
-      listRef: createListRef(container),
-    };
-
-    render(<StickyHeaderTester params={params} info={info} />);
-
-    const stickyHeader = container.querySelector(
-      `.${PREFIX_CLS}-group-header-fixed`,
-    );
-    expect(stickyHeader).not.toBeNull();
-    expect(stickyHeader).toHaveTextContent('Group 2');
-    expect(stickyHeader).toHaveStyle({ top: '0px' });
-    expect(title).toHaveBeenCalledWith('Group 2', baseItems.slice(3, 6));  });
 
   it('keeps the fixed header pinned at 0 within a group regardless of scroll', () => {
     const title = jest.fn().mockImplementation((key: React.Key) => (
@@ -311,7 +271,7 @@ describe('useStickyGroupHeader', () => {
         key: (item) => item.group,
         title,
       },
-      headerRows,
+      groupKeys,
       groupKeyToItems: baseItemsMap,
       prefixCls: PREFIX_CLS,
       listRef: createListRef(container),
@@ -353,7 +313,7 @@ describe('useStickyGroupHeader', () => {
         key: (item) => item.group,
         title,
       },
-      headerRows,
+      groupKeys,
       groupKeyToItems: baseItemsMap,
       prefixCls: PREFIX_CLS,
       listRef: createListRef(container),
@@ -367,4 +327,45 @@ describe('useStickyGroupHeader', () => {
     expect(stickyHeader).not.toBeNull();
     expect(stickyHeader).toHaveTextContent('Group 1');
     expect(stickyHeader).toHaveStyle({ top: '-10px' });  });
+
+  it('activates the current group, not the previous one, when its header sits flush at the top', () => {
+    const title = jest.fn().mockImplementation((key: React.Key) => (
+      <span data-testid="sticky-title">{String(key)}</span>
+    ));
+
+    // Group 2's header sits exactly at the viewport top (scrollTop === its top),
+    // while `start` is Group 1's last item row (3) — the row before Group 2's
+    // header row (4). This is the off-by-one boundary.
+    const info = createRenderInfo({
+      scrollTop: 200,
+      start: 3,
+      getSize: (key: React.Key) =>
+        key === 'Group 2' ? { top: 200, bottom: 220 } : { top: 0, bottom: 20 },
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const params: StickyHeaderParams<GroupedItem> = {
+      enabled: true,
+      group: {
+        key: (item) => item.group,
+        title,
+      },
+      groupKeys,
+      groupKeyToItems: baseItemsMap,
+      prefixCls: PREFIX_CLS,
+      listRef: createListRef(container),
+    };
+
+    render(<StickyHeaderTester params={params} info={info} />);
+
+    const stickyHeader = container.querySelector(
+      `.${PREFIX_CLS}-group-header-fixed`,
+    );
+    expect(stickyHeader).not.toBeNull();
+    // The current group (Group 2), not the previous one (Group 1).
+    expect(stickyHeader).toHaveTextContent('Group 2');
+    expect(stickyHeader).toHaveStyle({ top: '0px' });
+    expect(title).toHaveBeenCalledWith('Group 2', baseItems.slice(3, 6));
+  });
 });

--- a/tests/hooks.test.tsx
+++ b/tests/hooks.test.tsx
@@ -368,4 +368,42 @@ describe('useStickyGroupHeader', () => {
     expect(stickyHeader).toHaveStyle({ top: '0px' });
     expect(title).toHaveBeenCalledWith('Group 2', baseItems.slice(3, 6));
   });
+
+  it('tolerates a sub-pixel scroll offset just short of the header top', () => {
+    const title = jest.fn().mockImplementation((key: React.Key) => (
+      <span data-testid="sticky-title">{String(key)}</span>
+    ));
+
+    // On a HiDPI screen the scroll offset can rest a fraction of a pixel below
+    // a header's true top (here 199.5 vs 200). Without tolerance the strict
+    // compare resolves to the previous group and blanks the title.
+    const info = createRenderInfo({
+      scrollTop: 199.5,
+      start: 3,
+      getSize: (key: React.Key) =>
+        key === 'Group 2' ? { top: 200, bottom: 220 } : { top: 0, bottom: 20 },
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const params: StickyHeaderParams<GroupedItem> = {
+      enabled: true,
+      group: {
+        key: (item) => item.group,
+        title,
+      },
+      groupKeys,
+      groupKeyToItems: baseItemsMap,
+      prefixCls: PREFIX_CLS,
+      listRef: createListRef(container),
+    };
+
+    render(<StickyHeaderTester params={params} info={info} />);
+
+    const stickyHeader = container.querySelector(
+      `.${PREFIX_CLS}-group-header-fixed`,
+    );
+    expect(stickyHeader).not.toBeNull();
+    expect(stickyHeader).toHaveTextContent('Group 2');
+  });
 });


### PR DESCRIPTION
## Before

<img width="1280" height="720" alt="Clipboard-20260628-060614-174" src="https://github.com/user-attachments/assets/66768a5f-c821-44eb-9b69-939f9a29f57e" />

## After

<img width="1280" height="720" alt="Clipboard-20260628-121038-241" src="https://github.com/user-attachments/assets/1ec7c6ee-560e-4cea-aed6-5400aeffc769" />

## Problem

In the grouped sticky list the sticky header can render **blank** — it shows the *previous* group's header pinned off-screen instead of the current group's title. Two distinct triggers, same symptom:

1. **Jumping to a group** — `scrollTo({ groupKey, align: 'top' })` (e.g. `Scroll to G8` then `Scroll to G17`) lands a header **exactly** at the viewport top.
2. **Trackpad / momentum scrolling on a HiDPI (Retina) screen** — the scroll rests a fraction of a pixel short of a header top.

## Root cause

**1. Index vs pixel coordinate mismatch.** The active header was chosen from the virtual list's `start` row index:

```ts
findActiveHeaderIndex(headerRows, start) // last header with rowIndex <= start
```

but the overlay's `top` is computed in **pixels** (`getSize(...).top`, `scrollTop`). rc-virtual-list derives `start` with `currentItemBottom >= offsetTop`, so when a header sits flush at the top the previous group's trailing row (bottom === `scrollTop`) is still counted as `start` → the lookup picks the previous group and the `top` math pins that stale header at a negative offset, clipping the title.

**2. Sub-pixel rounding.** Selecting by pixel offset fixes (1), but `scrollTop` is rounded to the device's sub-pixel grid while header tops come from summed item heights. On a Retina screen a trackpad scroll routinely rests ~0.5px below a header's true top, so a strict `getSize(top) <= scrollTop` flips back to the previous group — the same blank, but only reachable via real (non-integer) scrolling rather than `scrollTo`.

## Fix

- **Select by pixel offset** (commit 1): `last header with getSize(groupKey).top <= scrollTop` — the same coordinate space as the positioning math, so selection and `top` can't disagree at an exact boundary.
- **Tolerate sub-pixel** (commit 2): compare with 1px of slack (`getSize(top) <= scrollTop + 1`). 1px absorbs the rounding (the sub-pixel grid is <1px at any DPR) yet is far below the gap between consecutive headers, so it never skips a header. At the 1px-early switch point the incoming header's `top` evaluates to exactly `0` (`items_next + 1 > 0`), so the tolerance can never re-introduce a negative/clipped header.

## Tests

- **Exact-alignment boundary** — header flush at the top while `start` points at the previous group's last row. Verified red→green against the old `start`-based code.
- **Sub-pixel offset** — `scrollTop` 0.5px short of a header top still resolves to the current group. Verified red→green (fails at strict `<=`, passes with the tolerance).
- Full unit suite green.
- Behaviour confirmed in a real Chrome at DPR 2: a fine-grained scroll sweep across a boundary switches cleanly — no blank, the incoming header pins at `top: 0`.

## Incidental cleanup

Once selection no longer needs row indices, `rowIndex` became dead — removed it, and collapsed the flatten hook's `headerRows: { groupKey: K }[]` to `groupKeys: K[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 虚拟列表的分组固定表头支持更稳定的滚动定位与切换。
  * 固定表头现在可正常悬浮在列表外部，显示效果更一致。

* **问题修复**
  * 修复分组表头在接近视口顶部、切换到下一组时的位置偏移问题。
  * 修复细微滚动偏差下，固定表头显示组别不准确的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
