### PR TITLE
fix: remove unnecessary/unsafe type assertions in RawList and VirtualList

### DIFF
--- a/src/RawList/index.tsx
+++ b/src/RawList/index.tsx
@@ -132,6 +132,11 @@ function RawList<T, K extends React.Key = React.Key>(
   );
 }
 
-const RawListWithRef = React.forwardRef(RawList as any) as any;
+const RawListWithRef = React.forwardRef(RawList) as <
+  T,
+  K extends React.Key = React.Key,
+>(
+  props: RawListProps<T, K> & { ref?: React.Ref<ListyRef> },
+) => React.ReactElement;
 
 export default RawListWithRef;

--- a/src/RawList/useRawListScroll.ts
+++ b/src/RawList/useRawListScroll.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ListyRef, PositionScrollToConfig, ScrollAlign } from '../List';
+import type { ListyRef, ScrollAlign } from '../List';
 
 export default function useRawListScroll(
   ref: React.Ref<ListyRef>,
@@ -87,7 +87,7 @@ export default function useRawListScroll(
         return;
       }
 
-      const { left, top } = config as PositionScrollToConfig;
+      const { left, top } = config;
       if (left !== undefined) {
         holder.scrollLeft = left;
       }

--- a/src/VirtualList/index.tsx
+++ b/src/VirtualList/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import RcVirtualList, {
   type ListRef as RcVirtualListRef,
+  type ScrollConfig,
   type ScrollOffsetInfo,
 } from '@rc-component/virtual-list';
 import { useEvent } from '@rc-component/util';
@@ -121,7 +122,7 @@ function VirtualList<T, K extends React.Key = React.Key>(
     }
 
     // Other scroll shapes are already supported by the underlying virtual list.
-    listRef.current?.scrollTo(config);
+    listRef.current?.scrollTo(config as number | ScrollConfig | null);
   });
 
   // ============================ Imperative ============================

--- a/src/VirtualList/index.tsx
+++ b/src/VirtualList/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import clsx from 'clsx';
 import RcVirtualList, {
   type ListRef as RcVirtualListRef,
-  type ScrollConfig,
   type ScrollOffsetInfo,
 } from '@rc-component/virtual-list';
 import { useEvent } from '@rc-component/util';
@@ -122,7 +121,7 @@ function VirtualList<T, K extends React.Key = React.Key>(
     }
 
     // Other scroll shapes are already supported by the underlying virtual list.
-    listRef.current?.scrollTo(config as number | ScrollConfig | null);
+    listRef.current?.scrollTo(config);
   });
 
   // ============================ Imperative ============================
@@ -197,6 +196,11 @@ function VirtualList<T, K extends React.Key = React.Key>(
   );
 }
 
-const VirtualListWithRef = React.forwardRef(VirtualList as any) as any;
+const VirtualListWithRef = React.forwardRef(VirtualList) as <
+  T,
+  K extends React.Key = React.Key,
+>(
+  props: VirtualListProps<T, K> & { ref?: React.Ref<ListyRef> },
+) => React.ReactElement;
 
 export default VirtualListWithRef;


### PR DESCRIPTION
## Summary
- Replaced the `React.forwardRef(X as any) as any` double-cast used for `RawListWithRef`/`VirtualListWithRef` with the same typed-cast pattern already used by `Listy`/`GroupHeader` in this codebase, restoring prop type checking on those exports.
- Removed the redundant `as PositionScrollToConfig` cast in `useRawListScroll` — control-flow narrowing already produces the correct type there (verified against both the root `typescript@6.0.3` and father's internally-pinned `typescript@5.4.2`).
- Left the `item[rowKey] as React.Key` casts in place — `T` is a fully generic type parameter, so a conditional/mapped type can't narrow `T[keyof T]` to `React.Key` for an abstract `T` (confirmed by attempting a `KeysMatching<T, React.Key>` restriction on `RowKey<T>`, which `tsc` rejects). This is a real boundary of the type system, not an oversight.
- Left the `config as number | ScrollConfig | null` cast in `VirtualList`'s `scrollTo` in place too. It initially looked removable under the root `typescript@6.0.3`, but `pnpm compile` failed: father resolves its own `typescript@5.4.2` for declaration generation, and that version doesn't narrow the `'key' in config || 'groupKey' in config` early-return pattern precisely enough to drop `GroupScrollToConfig` from the union, so it still needs the cast.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` (typescript@6.0.3)
- [x] father's internal `typescript@5.4.2` via direct `tsc --noEmit -p tsconfig.json`
- [x] `pnpm compile` (father build + declaration generation)
- [x] `npx eslint src/ --ext .tsx,.ts`
- [x] `npx rc-test` (4 suites, 40 tests, all passing)