### PR TITLE
ci: bump react-doctor action to fix failing job

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: millionco/react-doctor@0b4f4f4bd248a154e64eb508a48347f71154b3f3
+      - uses: millionco/react-doctor@964622bf15fa5f8eef7e05196407aa08dc779087


### PR DESCRIPTION
## Summary
- The React Doctor CI job is failing because the pinned action commit `millionco/react-doctor@0b4f4f4` no longer resolves.
- Bump the pin to `964622b` to restore the job.

## Test plan
- [ ] React Doctor job passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)