### PR TITLE
chore: generate declarations with tsgo (TypeScript 7 native compiler)

### DIFF
--- a/.fatherrc.js
+++ b/.fatherrc.js
@@ -2,4 +2,5 @@ import { defineConfig } from 'father';
 
 export default defineConfig({
   plugins: ['@rc-component/father-plugin'],
+  dts: { compiler: 'tsgo' },
 });

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "start": "dumi dev",
     "build": "dumi build",
-    "compile": "father build && lessc assets/index.less assets/index.css",
+    "compile": "cross-env FATHER_TSCONFIG_NAME=tsconfig.build.json father build && lessc assets/index.less assets/index.css",
     "prepublishOnly": "npm run compile && rc-np",
     "lint": "eslint src/ docs/examples/ --ext .tsx,.ts,.jsx,.js",
     "test": "rc-test",
@@ -57,6 +57,7 @@
     "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "cross-env": "^10.1.0",
     "dumi": "^2.4.38",
     "eslint": "^10.6.0",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "es", "lib", "dist", "docs-dist", ".doc", ".dumi", "coverage", "tests"]
+}


### PR DESCRIPTION
## What

Generate `.d.ts` with the tsgo (TypeScript 7 native) compiler, via father's `dts.compiler: 'tsgo'` option.

## Why

father's default declaration path bundles and runs `typescript@5.4.2` regardless of the project's own TypeScript. Opting into tsgo runs the TS7 native compiler instead — declaration generation is several times faster here, and the emitted types stay aligned with a modern compiler.

## Notes

- tsgo is resolved from a separately-named `@typescript/native-preview` package, and this intentionally does **not** raise the shared `typescript` dependency to 7. TypeScript 7 is the native compiler and its package no longer exposes the classic JS compiler API, so type-aware tooling that imports it breaks — e.g. `@typescript-eslint` (used both by father-plugin's build-time export check and by `lint`) throws `Cannot read properties of undefined (reading 'Any')`. Keeping `typescript` at 6 for that tooling while using tsgo purely as a CLI for declaration emit avoids the fallout.
- tsgo enforces `rootDir` strictly, and father passes it the full tsconfig file list (including `tests/**`), which trips `TS6059`. `tsconfig.build.json` scopes the declaration build to `src/` and is wired in through `FATHER_TSCONFIG_NAME`; the main `tsconfig.json` used by the editor and jest is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
